### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 ---
 name: ci
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   # for feature branches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,7 @@
 ---
 name: ci
 permissions:
-  contents: read
-  pull-requests: write
+  contents: write
 
 on:
   # for feature branches


### PR DESCRIPTION
Potential fix for [https://github.com/kivra/context/security/code-scanning/1](https://github.com/kivra/context/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the operations performed in the workflow, the following permissions are necessary:
- `contents: read` for reading repository contents.
- `pull-requests: write` for operations related to pull requests, if applicable.
- Additional permissions (e.g., `contents: write`) may be required for the `git push` operation.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`ci`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
